### PR TITLE
changed to opps

### DIFF
--- a/include/zoomzoom.h
+++ b/include/zoomzoom.h
@@ -31,7 +31,7 @@
 #define W EXIT_SUCCESS
 #define L EXIT_FAILURE
 #define ratios >
-#define stans < 
+#define opps < 
 #define GOAT INT_MAX
 
 #endif


### PR DESCRIPTION
its common slang term. better than stans in my opinion, and used more often. ex: "we be getting rid of the opps and that's on gang."